### PR TITLE
Updated reagent dependency; added re-frame example

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,45 @@ This component renders as a small box label "data frisk" which expands into a na
 
 Et viola!
 
+### Use with re-frame
+
+This example uses [re-frame](https://github.com/Day8/re-frame) to display a data-frisk component displaying the current app database:
+
+```clojure
+(ns datafrisk.re-frame-example
+  (:require [reagent.core :as r]
+            [datafrisk.core :as d]
+            [re-frame.core :refer [subscribe reg-sub]]))
+
+;; Set up a subscription
+(defn- app-db-subscription
+  "Subscribe to any change in the app db under the path"
+  [db [_ path]]
+  (get-in db path))
+(reg-sub :debug/everything app-db-subscription)
+
+;; Define a form-2 component
+(defn frisk
+  [& path]
+  (let [everything (subscribe [:debug/everything path])]
+    (fn [& path]
+      [d/DataFriskShell @everything])))
+
+;; Now you can use the component thusly:
+
+(defn mount-root []
+  (r/render
+    [:div
+     [:h1 "Welcome to ZomboCom"]
+
+     ;; This displays the entire app database:
+     [frisk]
+
+     ;; This displays everything under a specific subtree:
+     [frisk :subtree :that :interests-me]]
+
+    (js/document.getElementById "app")))
+```
 
 ### For more
 

--- a/project.clj
+++ b/project.clj
@@ -6,8 +6,7 @@
   :min-lein-version "2.6.1"
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/clojurescript "1.7.228"]
-                 [reagent "0.6.0-alpha" :exclusions [cljsjs/react]]
-                 [cljsjs/react-with-addons "0.14.3-0"]]
+                 [reagent "0.6.0"]]
   :plugins [[lein-figwheel "0.5.2"]
             [lein-cljsbuild "1.1.3" :exclusions [[org.clojure/clojure]]]]
   :source-paths ["src"]


### PR DESCRIPTION
This removes the unused react-with-addons dependency and depends on reagent to supply the react dependency, which should fix #8. (I also updated the dependency to reagent 0.6.0, everything seems to work in my local testing.)

I also added a section to the README describing how to use data-frisk with re-frame, which is not incredibly difficult but seems like handy information to have an example for.

If you're interested, I could file another PR that would include the described component from the example in the data-frisk library itself, which would be handy for re-frame users.
