### PR TITLE
Add z-index to frisk container

### DIFF
--- a/src/datafrisk/core.cljs
+++ b/src/datafrisk/core.cljs
@@ -16,7 +16,8 @@
 (def styles
   {:shell {:backgroundColor "#FAFAFA"
            :fontFamily "Consolas,Monaco,Courier New,monospace"
-           :fontSize "12px"}
+           :fontSize "12px"
+           :z-index 9999}
    :strings {:color "#4Ebb4E"}
    :keywords {:color "purple"}
    :numbers {:color "blue"}


### PR DESCRIPTION
In some situation, the frisk container was overlayed by site content because they had a higher z-index than the container to solve this adds some high z-index.
Fixes #13
